### PR TITLE
Add JSDoc markup to header comment to keep it on minify

### DIFF
--- a/js/md5.js
+++ b/js/md5.js
@@ -1,13 +1,13 @@
-/*
+/*!
  * JavaScript MD5 1.0.1
  * https://github.com/blueimp/JavaScript-MD5
  *
- * Copyright 2011, Sebastian Tschan
+ * @copyright Copyright 2011, Sebastian Tschan
  * https://blueimp.net
  *
- * Licensed under the MIT license:
+ * @license Licensed under the MIT license:
  * http://www.opensource.org/licenses/MIT
- * 
+ *
  * Based on
  * A JavaScript implementation of the RSA Data Security, Inc. MD5 Message
  * Digest Algorithm, as defined in RFC 1321.


### PR DESCRIPTION
Some minifier keep header comment over its format.
1. YUI Compressor
   It keeps the header comments beggining with `/*!`
   - http://yui.github.io/yuicompressor/css.html#special-comments
2. Closure compiler
   It keeps the header comments containing `@license` or `@preserve`
   - https://developers.google.com/closure/compiler/docs/js-for-compiler#tag-license

I think header comment is very important because it includes its own license.
