### PR TITLE
Use common.js if possible.

### DIFF
--- a/js/md5.js
+++ b/js/md5.js
@@ -264,7 +264,9 @@
         return raw_hmac_md5(key, string);
     }
 
-    if (typeof define === 'function' && define.amd) {
+    if (typeof module !== 'undefined') {
+        module.exports = {md5: md5};
+    } else if (typeof define === 'function' && define.amd) {
         define(function () {
             return md5;
         });


### PR DESCRIPTION
I made `{md5: md5} ` export because in d.ts definition https://github.com/borisyankov/DefinitelyTyped/blob/master/blueimp-md5/blueimp-md5.d.ts it is defined like {md5: md5} :)