### PR TITLE
Add semicolon to unminified source

### DIFF
--- a/js/md5.js
+++ b/js/md5.js
@@ -278,4 +278,4 @@
   } else {
     $.md5 = md5
   }
-}(this))
+}(this));


### PR DESCRIPTION
I realize that one could use the minified source instead, but sometimes unminified code is easier to use for debugging purposes.

This may seem like a petty change, but adding a semicolon at the end of this file should solve issues with some build pipelines that choke on this thing. See http://stackoverflow.com/questions/20307462/js-cant-combine-lib-files

I just ran into this issue myself and so I thought I'd submit a PR for this.