### PR TITLE
Adding a semicolon at the end

### DIFF
--- a/js/md5.js
+++ b/js/md5.js
@@ -277,4 +277,4 @@
   } else {
     $.md5 = md5
   }
-})(this)
+})(this);


### PR DESCRIPTION
A semicolon at the end is needed to prevent "Uncaught TypeError: (intermediate value)(…) is not a function" in situations where md5.js is bundled with other libraries.